### PR TITLE
Update to scalajs 0.6.18 and change main signature

### DIFF
--- a/core/src/main/scala/io/udash/generator/plugins/core/CorePlugin.scala
+++ b/core/src/main/scala/io/udash/generator/plugins/core/CorePlugin.scala
@@ -78,11 +78,10 @@ object CorePlugin extends GeneratorPlugin with SBTProjectFiles with FrontendPath
          |  implicit val applicationInstance = new Application[RoutingState](routingRegistry, viewPresenterRegistry, RootState)$FrontendContextPlaceholder
          |}
          |
-         |object Init extends JSApp with StrictLogging {
+         |object Init extends StrictLogging {
          |  import Context._
          |
-         |  @JSExport
-         |  override def main(): Unit = {
+         |  def main(args: Array[String]): Unit = {
          |    jQ(document).ready((_: Element) => {
          |      val appRoot = jQ("#${settings.htmlRootId}").get(0)
          |      if (appRoot.isEmpty) {


### PR DESCRIPTION
[Scala-js 0.6.18](https://www.scala-js.org/news/2017/06/28/announcing-scalajs-0.6.18/) is out with the support for standard jvm main methods. To me they are more familiar to Scala programmers.